### PR TITLE
Update puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-shell": "^1.1.1",
-    "puppeteer": "^0.9.0"
+    "puppeteer": "^1.17.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"


### PR DESCRIPTION
I haven't tested, but there should be an update at least to 1.13.0 per `npm audit`. See https://npmjs.com/advisories/824